### PR TITLE
Improve NotFoundException and harden JWT authorization filter

### DIFF
--- a/src/main/kotlin/com/renato/springbootstrap/exception/NotFoundException.kt
+++ b/src/main/kotlin/com/renato/springbootstrap/exception/NotFoundException.kt
@@ -1,9 +1,3 @@
 package com.renato.springbootstrap.exception
 
-import java.util.function.Supplier
-
-class NotFoundException(override var message : String) : RuntimeException(), Supplier<Throwable> {
-    override fun get(): Throwable {
-        return this
-    }
-}
+class NotFoundException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/src/main/kotlin/com/renato/springbootstrap/security/filter/JwtAuthorizationFilter.kt
+++ b/src/main/kotlin/com/renato/springbootstrap/security/filter/JwtAuthorizationFilter.kt
@@ -14,7 +14,7 @@ import org.springframework.web.filter.OncePerRequestFilter
 @Component
 class JwtAuthorizationFilter(private val jwtUtils: JwtUtils) : OncePerRequestFilter() {
     companion object {
-        const val TOKEN_PREFIX = "Bearer"
+        const val TOKEN_PREFIX = "Bearer "
     }
 
     override fun doFilterInternal(
@@ -22,16 +22,13 @@ class JwtAuthorizationFilter(private val jwtUtils: JwtUtils) : OncePerRequestFil
             response: HttpServletResponse,
             filterChain: FilterChain
     ) {
-        val header = request.getHeader(HttpHeaders.AUTHORIZATION)
-
-        if (header == null || !header.startsWith(TOKEN_PREFIX)) {
+        val token = resolveToken(request.getHeader(HttpHeaders.AUTHORIZATION))
+        if (token == null) {
             filterChain.doFilter(request, response);
             return
         }
-        
-        val token = getToken(header)
 
-        if(jwtUtils.validateJwtToken(token)) {
+        if (SecurityContextHolder.getContext().authentication == null && jwtUtils.validateJwtToken(token)) {
             val userDetails = jwtUtils.toUserDetails(token)
             val authentication = UsernamePasswordAuthenticationToken(userDetails, null, userDetails.authorities)
             authentication.details = WebAuthenticationDetailsSource().buildDetails(request)
@@ -41,7 +38,10 @@ class JwtAuthorizationFilter(private val jwtUtils: JwtUtils) : OncePerRequestFil
         filterChain.doFilter(request, response)
     }
 
-    private fun getToken(header: String): String {
-        return header.substring(7, header.length)
+    private fun resolveToken(header: String?): String? {
+        if (header.isNullOrBlank() || !header.startsWith(TOKEN_PREFIX, ignoreCase = true)) {
+            return null
+        }
+        return header.substring(TOKEN_PREFIX.length).trim().takeIf { it.isNotEmpty() }
     }
 }

--- a/src/main/kotlin/com/renato/springbootstrap/security/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/renato/springbootstrap/security/service/UserServiceImpl.kt
@@ -42,7 +42,7 @@ class UserServiceImpl (
     override fun getUserByUserId(userId: Long): UserEntity {
         return userRepository
             .findById(userId)
-            .orElseThrow(NotFoundException(String.format("User %d cannot be found", userId)))
+            .orElseThrow { NotFoundException(String.format("User %d cannot be found", userId)) }
     }
 
     override fun getUserByUsername(username: String): UserEntity {

--- a/src/test/kotlin/com/renato/springbootstrap/exception/NotFoundExceptionTest.kt
+++ b/src/test/kotlin/com/renato/springbootstrap/exception/NotFoundExceptionTest.kt
@@ -2,25 +2,26 @@ package com.renato.springbootstrap.exception
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class NotFoundExceptionTest {
 
     @Test
-    fun `given_not_found_exception_when_get_is_called_then_same_instance_is_returned`() {
+    fun `given_not_found_exception_when_created_then_message_is_preserved_and_throwable`() {
         val exception = NotFoundException("not found")
 
-        val supplied = exception.get()
-
         assertThat(exception.message).isEqualTo("not found")
-        assertThat(supplied).isSameAs(exception)
+        assertThrows<NotFoundException> {
+            throw exception
+        }
     }
 
     @Test
-    fun `given_not_found_exception_when_message_is_updated_then_new_message_is_exposed`() {
-        val exception = NotFoundException("initial")
+    fun `given_not_found_exception_with_cause_when_created_then_cause_is_preserved`() {
+        val cause = IllegalStateException("root cause")
 
-        exception.message = "updated"
+        val exception = NotFoundException("not found", cause)
 
-        assertThat(exception.message).isEqualTo("updated")
+        assertThat(exception.cause).isSameAs(cause)
     }
 }

--- a/src/test/kotlin/com/renato/springbootstrap/security/filter/JwtAuthorizationFilterTest.kt
+++ b/src/test/kotlin/com/renato/springbootstrap/security/filter/JwtAuthorizationFilterTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.provider.NullSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.Mockito.anyString
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
@@ -21,6 +22,7 @@ import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.http.HttpHeaders
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import java.util.UUID
 
@@ -40,9 +42,9 @@ class JwtAuthorizationFilterTest {
 
     @Test
     fun `given_valid_bearer_token_when_filter_executes_then_request_is_authenticated`() {
-        val request = org.mockito.Mockito.mock(HttpServletRequest::class.java)
-        val response = org.mockito.Mockito.mock(HttpServletResponse::class.java)
-        val filterChain = org.mockito.Mockito.mock(FilterChain::class.java)
+        val request = Mockito.mock(HttpServletRequest::class.java)
+        val response = Mockito.mock(HttpServletResponse::class.java)
+        val filterChain = Mockito.mock(FilterChain::class.java)
         val userDetails = UserSecurity(
             id = 1L,
             userId = UUID.randomUUID(),
@@ -68,9 +70,9 @@ class JwtAuthorizationFilterTest {
 
     @Test
     fun `given_invalid_bearer_token_when_filter_executes_then_request_is_not_authenticated`() {
-        val request = org.mockito.Mockito.mock(HttpServletRequest::class.java)
-        val response = org.mockito.Mockito.mock(HttpServletResponse::class.java)
-        val filterChain = org.mockito.Mockito.mock(FilterChain::class.java)
+        val request = Mockito.mock(HttpServletRequest::class.java)
+        val response = Mockito.mock(HttpServletResponse::class.java)
+        val filterChain = Mockito.mock(FilterChain::class.java)
 
         `when`(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer token")
         `when`(jwtUtils.validateJwtToken("token")).thenReturn(false)
@@ -86,16 +88,63 @@ class JwtAuthorizationFilterTest {
 
     @ParameterizedTest
     @NullSource
-    @ValueSource(strings = ["", "Basic abc", "Token xyz"])
+    @ValueSource(strings = ["", "Basic abc", "Token xyz", "Bearer", "Bearer   "])
     fun `given_missing_or_non_bearer_header_when_filter_executes_then_jwt_processing_is_skipped`(header: String?) {
-        val request = org.mockito.Mockito.mock(HttpServletRequest::class.java)
-        val response = org.mockito.Mockito.mock(HttpServletResponse::class.java)
-        val filterChain = org.mockito.Mockito.mock(FilterChain::class.java)
+        val request = Mockito.mock(HttpServletRequest::class.java)
+        val response = Mockito.mock(HttpServletResponse::class.java)
+        val filterChain = Mockito.mock(FilterChain::class.java)
 
         `when`(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn(header)
 
         jwtAuthorizationFilter.doFilter(request, response, filterChain)
 
+        verify(jwtUtils, never()).validateJwtToken(anyString())
+        verify(jwtUtils, never()).toUserDetails(anyString())
+        verify(filterChain).doFilter(request, response)
+        verifyNoMoreInteractions(jwtUtils, filterChain)
+    }
+
+    @Test
+    fun `given_lowercase_bearer_prefix_when_filter_executes_then_token_is_processed`() {
+        val request = Mockito.mock(HttpServletRequest::class.java)
+        val response = Mockito.mock(HttpServletResponse::class.java)
+        val filterChain = Mockito.mock(FilterChain::class.java)
+        val userDetails = UserSecurity(
+            id = 1L,
+            userId = UUID.randomUUID(),
+            username = "username",
+            password = "password",
+            email = "email",
+            authorities = emptyList(),
+            roles = listOf("USER"),
+        )
+
+        `when`(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("bearer token")
+        `when`(jwtUtils.validateJwtToken("token")).thenReturn(true)
+        `when`(jwtUtils.toUserDetails("token")).thenReturn(userDetails)
+
+        jwtAuthorizationFilter.doFilter(request, response, filterChain)
+
+        assertThat(SecurityContextHolder.getContext().authentication?.principal).isEqualTo(userDetails)
+        verify(jwtUtils).validateJwtToken("token")
+        verify(jwtUtils).toUserDetails("token")
+        verify(filterChain).doFilter(request, response)
+        verifyNoMoreInteractions(jwtUtils, filterChain)
+    }
+
+    @Test
+    fun `given_existing_authentication_when_filter_executes_then_jwt_processing_is_skipped`() {
+        val request = Mockito.mock(HttpServletRequest::class.java)
+        val response = Mockito.mock(HttpServletResponse::class.java)
+        val filterChain = Mockito.mock(FilterChain::class.java)
+        val existingAuthentication = UsernamePasswordAuthenticationToken("existing", null, emptyList())
+        SecurityContextHolder.getContext().authentication = existingAuthentication
+
+        `when`(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer token")
+
+        jwtAuthorizationFilter.doFilter(request, response, filterChain)
+
+        assertThat(SecurityContextHolder.getContext().authentication).isSameAs(existingAuthentication)
         verify(jwtUtils, never()).validateJwtToken(anyString())
         verify(jwtUtils, never()).toUserDetails(anyString())
         verify(filterChain).doFilter(request, response)


### PR DESCRIPTION
## Summary
- refactor NotFoundException into a standard immutable RuntimeException with optional cause
- update UserServiceImpl to use lazy orElseThrow construction for NotFoundException
- harden JwtAuthorizationFilter token parsing and skip JWT processing when authentication already exists
- expand tests for NotFoundException and JwtAuthorizationFilter edge cases

## Validation
- ./gradlew test --tests "com.renato.springbootstrap.exception.NotFoundExceptionTest" --tests "com.renato.springbootstrap.security.filter.JwtAuthorizationFilterTest"