### PR TITLE
Improve REST error response contract and tests

### DIFF
--- a/src/main/kotlin/com/renato/springbootstrap/api/response/GeneralFailureResponse.kt
+++ b/src/main/kotlin/com/renato/springbootstrap/api/response/GeneralFailureResponse.kt
@@ -1,3 +1,13 @@
 package com.renato.springbootstrap.api.response
 
-data class GeneralFailureResponse(val errors : List<String>)
+import java.time.Instant
+
+data class GeneralFailureResponse(
+    val timestamp: Instant,
+    val status: Int,
+    val error: String,
+    val code: String,
+    val message: String,
+    val path: String,
+    val details: List<String> = emptyList(),
+)

--- a/src/main/kotlin/com/renato/springbootstrap/api/response/GeneralFailureResponse.kt
+++ b/src/main/kotlin/com/renato/springbootstrap/api/response/GeneralFailureResponse.kt
@@ -9,5 +9,4 @@ data class GeneralFailureResponse(
     val code: String,
     val message: String,
     val path: String,
-    val details: List<String> = emptyList(),
 )

--- a/src/main/kotlin/com/renato/springbootstrap/exception/ExceptionHandler.kt
+++ b/src/main/kotlin/com/renato/springbootstrap/exception/ExceptionHandler.kt
@@ -3,6 +3,7 @@ package com.renato.springbootstrap.exception
 import com.renato.springbootstrap.api.response.GeneralFailureResponse
 import com.renato.springbootstrap.security.exception.JwtException
 import com.renato.springbootstrap.security.exception.UserAlreadyExistsException
+import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -11,42 +12,105 @@ import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import java.time.Instant
 
 @RestControllerAdvice
 class ExceptionHandler {
     private val logger: Logger = LoggerFactory.getLogger(ExceptionHandler::class.java)
 
     @ExceptionHandler(AccessDeniedException::class)
-    fun handle(ex: AccessDeniedException): ResponseEntity<Any> {
-        logger.error(ex.localizedMessage,ex)
-        return ResponseEntity(generateErrorResponse(ex.localizedMessage), HttpStatus.FORBIDDEN)
+    fun handle(ex: AccessDeniedException, request: HttpServletRequest): ResponseEntity<GeneralFailureResponse> {
+        logger.warn(ex.localizedMessage, ex)
+        return buildErrorResponse(
+            status = HttpStatus.FORBIDDEN,
+            code = "ACCESS_DENIED",
+            message = ex.localizedMessage,
+            request = request,
+        )
     }
 
     @ExceptionHandler(UserAlreadyExistsException::class)
-    fun handle(ex: UserAlreadyExistsException): ResponseEntity<Any> {
-        logger.error(ex.localizedMessage,ex)
-        return ResponseEntity(generateErrorResponse(ex.localizedMessage),HttpStatus.CONFLICT)
+    fun handle(ex: UserAlreadyExistsException, request: HttpServletRequest): ResponseEntity<GeneralFailureResponse> {
+        logger.warn(ex.localizedMessage, ex)
+        return buildErrorResponse(
+            status = HttpStatus.CONFLICT,
+            code = "USER_ALREADY_EXISTS",
+            message = ex.localizedMessage,
+            request = request,
+        )
     }
 
     @ExceptionHandler(BadCredentialsException::class)
-    fun handle(ex: BadCredentialsException): ResponseEntity<Any> {
-        logger.error(ex.localizedMessage,ex)
-        return ResponseEntity(generateErrorResponse(ex.localizedMessage),HttpStatus.NOT_FOUND)
+    fun handle(ex: BadCredentialsException, request: HttpServletRequest): ResponseEntity<GeneralFailureResponse> {
+        logger.warn(ex.localizedMessage, ex)
+        return buildErrorResponse(
+            status = HttpStatus.UNAUTHORIZED,
+            code = "BAD_CREDENTIALS",
+            message = ex.localizedMessage,
+            request = request,
+        )
+    }
+
+    @ExceptionHandler(JwtException::class)
+    fun handle(ex: JwtException, request: HttpServletRequest): ResponseEntity<GeneralFailureResponse> {
+        logger.warn(ex.localizedMessage, ex)
+        return buildErrorResponse(
+            status = HttpStatus.UNAUTHORIZED,
+            code = "INVALID_TOKEN",
+            message = ex.localizedMessage,
+            request = request,
+        )
+    }
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handle(ex: IllegalArgumentException, request: HttpServletRequest): ResponseEntity<GeneralFailureResponse> {
+        logger.warn(ex.localizedMessage, ex)
+        return buildErrorResponse(
+            status = HttpStatus.BAD_REQUEST,
+            code = "BAD_REQUEST",
+            message = ex.localizedMessage,
+            request = request,
+        )
     }
 
     @ExceptionHandler(Exception::class)
-    fun handle(ex: Exception): ResponseEntity<Any> {
-        logger.error(ex.localizedMessage,ex)
-        return ResponseEntity(generateErrorResponse(ex.localizedMessage), HttpStatus.INTERNAL_SERVER_ERROR)
+    fun handle(ex: Exception, request: HttpServletRequest): ResponseEntity<GeneralFailureResponse> {
+        logger.error(ex.localizedMessage, ex)
+        return buildErrorResponse(
+            status = HttpStatus.INTERNAL_SERVER_ERROR,
+            code = "INTERNAL_ERROR",
+            message = ex.localizedMessage,
+            request = request,
+        )
     }
 
     @ExceptionHandler(RuntimeException::class)
-    fun handle(ex: RuntimeException): ResponseEntity<Any> {
+    fun handle(ex: RuntimeException, request: HttpServletRequest): ResponseEntity<GeneralFailureResponse> {
         logger.error(ex.localizedMessage, ex)
-        return ResponseEntity(generateErrorResponse(ex.localizedMessage), HttpStatus.INTERNAL_SERVER_ERROR)
+        return buildErrorResponse(
+            status = HttpStatus.INTERNAL_SERVER_ERROR,
+            code = "RUNTIME_ERROR",
+            message = ex.localizedMessage,
+            request = request,
+        )
     }
 
-    private fun generateErrorResponse(message : String) : GeneralFailureResponse {
-        return GeneralFailureResponse(listOf(message))
+    private fun buildErrorResponse(
+        status: HttpStatus,
+        code: String,
+        message: String?,
+        request: HttpServletRequest,
+        details: List<String> = emptyList(),
+    ): ResponseEntity<GeneralFailureResponse> {
+        val response = GeneralFailureResponse(
+            timestamp = Instant.now(),
+            status = status.value(),
+            error = status.reasonPhrase,
+            code = code,
+            message = message?.ifBlank { status.reasonPhrase } ?: status.reasonPhrase,
+            path = request.requestURI,
+            details = details,
+        )
+        return ResponseEntity.status(status).body(response)
     }
 }

--- a/src/main/kotlin/com/renato/springbootstrap/exception/ExceptionHandler.kt
+++ b/src/main/kotlin/com/renato/springbootstrap/exception/ExceptionHandler.kt
@@ -100,17 +100,22 @@ class ExceptionHandler {
         code: String,
         message: String?,
         request: HttpServletRequest,
-        details: List<String> = emptyList(),
     ): ResponseEntity<GeneralFailureResponse> {
+        val responseMessage = normalizeMessage(message, status.reasonPhrase)
         val response = GeneralFailureResponse(
             timestamp = Instant.now(),
             status = status.value(),
             error = status.reasonPhrase,
             code = code,
-            message = message?.ifBlank { status.reasonPhrase } ?: status.reasonPhrase,
+            message = responseMessage,
             path = request.requestURI,
-            details = details,
         )
         return ResponseEntity.status(status).body(response)
+    }
+
+    private fun normalizeMessage(message: String?, fallback: String): String {
+        if (message == null) return fallback
+        if (message.isBlank()) return fallback
+        return message
     }
 }

--- a/src/test/kotlin/com/renato/springbootstrap/api/response/GeneralFailureResponseTest.kt
+++ b/src/test/kotlin/com/renato/springbootstrap/api/response/GeneralFailureResponseTest.kt
@@ -1,0 +1,63 @@
+package com.renato.springbootstrap.api.response
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class GeneralFailureResponseTest {
+
+    @Test
+    fun `given_response_values_when_constructed_then_all_fields_are_mapped`() {
+        val timestamp = Instant.parse("2026-04-25T10:15:30Z")
+
+        val response = GeneralFailureResponse(
+            timestamp = timestamp,
+            status = 401,
+            error = "Unauthorized",
+            code = "BAD_CREDENTIALS",
+            message = "Invalid username or password",
+            path = "/api/auth/login",
+            details = listOf("username must not be blank"),
+        )
+
+        assertThat(response.timestamp).isEqualTo(timestamp)
+        assertThat(response.status).isEqualTo(401)
+        assertThat(response.error).isEqualTo("Unauthorized")
+        assertThat(response.code).isEqualTo("BAD_CREDENTIALS")
+        assertThat(response.message).isEqualTo("Invalid username or password")
+        assertThat(response.path).isEqualTo("/api/auth/login")
+        assertThat(response.details).containsExactly("username must not be blank")
+    }
+
+    @Test
+    fun `given_details_not_provided_when_constructed_then_details_defaults_to_empty`() {
+        val response = GeneralFailureResponse(
+            timestamp = Instant.parse("2026-04-25T10:15:30Z"),
+            status = 500,
+            error = "Internal Server Error",
+            code = "INTERNAL_ERROR",
+            message = "Unexpected error",
+            path = "/api/users",
+        )
+
+        assertThat(response.details).isEmpty()
+    }
+
+    @Test
+    fun `given_same_field_values_when_compared_then_objects_are_equal`() {
+        val timestamp = Instant.parse("2026-04-25T10:15:30Z")
+        val expected = GeneralFailureResponse(
+            timestamp = timestamp,
+            status = 400,
+            error = "Bad Request",
+            code = "BAD_REQUEST",
+            message = "Malformed payload",
+            path = "/api/users",
+            details = listOf("email is invalid"),
+        )
+        val actual = expected.copy()
+
+        assertThat(actual).isEqualTo(expected)
+        assertThat(actual.hashCode()).isEqualTo(expected.hashCode())
+    }
+}

--- a/src/test/kotlin/com/renato/springbootstrap/api/response/GeneralFailureResponseTest.kt
+++ b/src/test/kotlin/com/renato/springbootstrap/api/response/GeneralFailureResponseTest.kt
@@ -17,7 +17,6 @@ class GeneralFailureResponseTest {
             code = "BAD_CREDENTIALS",
             message = "Invalid username or password",
             path = "/api/auth/login",
-            details = listOf("username must not be blank"),
         )
 
         assertThat(response.timestamp).isEqualTo(timestamp)
@@ -26,21 +25,6 @@ class GeneralFailureResponseTest {
         assertThat(response.code).isEqualTo("BAD_CREDENTIALS")
         assertThat(response.message).isEqualTo("Invalid username or password")
         assertThat(response.path).isEqualTo("/api/auth/login")
-        assertThat(response.details).containsExactly("username must not be blank")
-    }
-
-    @Test
-    fun `given_details_not_provided_when_constructed_then_details_defaults_to_empty`() {
-        val response = GeneralFailureResponse(
-            timestamp = Instant.parse("2026-04-25T10:15:30Z"),
-            status = 500,
-            error = "Internal Server Error",
-            code = "INTERNAL_ERROR",
-            message = "Unexpected error",
-            path = "/api/users",
-        )
-
-        assertThat(response.details).isEmpty()
     }
 
     @Test
@@ -53,7 +37,6 @@ class GeneralFailureResponseTest {
             code = "BAD_REQUEST",
             message = "Malformed payload",
             path = "/api/users",
-            details = listOf("email is invalid"),
         )
         val actual = expected.copy()
 

--- a/src/test/kotlin/com/renato/springbootstrap/security/exception/handler/ErrorHandlerTest.kt
+++ b/src/test/kotlin/com/renato/springbootstrap/security/exception/handler/ErrorHandlerTest.kt
@@ -2,16 +2,18 @@ package com.renato.springbootstrap.security.exception.handler
 
 import com.renato.springbootstrap.api.response.GeneralFailureResponse
 import com.renato.springbootstrap.exception.ExceptionHandler
+import com.renato.springbootstrap.security.exception.JwtException
 import com.renato.springbootstrap.security.exception.UserAlreadyExistsException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.authentication.BadCredentialsException
-import org.springframework.mock.web.MockHttpServletRequest
 import java.util.stream.Stream
 
 class ErrorHandlerTest {
@@ -51,6 +53,70 @@ class ErrorHandlerTest {
         assertThat(body.path).isEqualTo("/api/auth/login")
         assertThat(body.details).isEmpty()
         assertThat(body.timestamp).isNotNull()
+    }
+
+    @Test
+    fun `given_jwt_exception_when_handle_then_returns_unauthorized_with_invalid_token_code`() {
+        val request = MockHttpServletRequest().apply {
+            requestURI = "/api/auth/refresh"
+        }
+
+        val response = errorHandler.handle(JwtException("token invalid"), request)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
+        val body = response.body as GeneralFailureResponse
+        assertThat(body.message).isEqualTo("token invalid")
+        assertThat(body.status).isEqualTo(HttpStatus.UNAUTHORIZED.value())
+        assertThat(body.error).isEqualTo(HttpStatus.UNAUTHORIZED.reasonPhrase)
+        assertThat(body.code).isEqualTo("INVALID_TOKEN")
+        assertThat(body.path).isEqualTo("/api/auth/refresh")
+        assertThat(body.details).isEmpty()
+    }
+
+    @Test
+    fun `given_illegal_argument_when_handle_then_returns_bad_request_with_bad_request_code`() {
+        val request = MockHttpServletRequest().apply {
+            requestURI = "/api/users"
+        }
+
+        val response = errorHandler.handle(IllegalArgumentException("invalid payload"), request)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        val body = response.body as GeneralFailureResponse
+        assertThat(body.message).isEqualTo("invalid payload")
+        assertThat(body.status).isEqualTo(HttpStatus.BAD_REQUEST.value())
+        assertThat(body.error).isEqualTo(HttpStatus.BAD_REQUEST.reasonPhrase)
+        assertThat(body.code).isEqualTo("BAD_REQUEST")
+        assertThat(body.path).isEqualTo("/api/users")
+        assertThat(body.details).isEmpty()
+    }
+
+    @Test
+    fun `given_blank_message_when_handle_then_response_uses_http_reason_phrase`() {
+        val request = MockHttpServletRequest().apply {
+            requestURI = "/api/users"
+        }
+
+        val response = errorHandler.handle(RuntimeException("   "), request)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        val body = response.body as GeneralFailureResponse
+        assertThat(body.message).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.reasonPhrase)
+        assertThat(body.code).isEqualTo("RUNTIME_ERROR")
+    }
+
+    @Test
+    fun `given_null_message_when_handle_then_response_uses_http_reason_phrase`() {
+        val request = MockHttpServletRequest().apply {
+            requestURI = "/api/users"
+        }
+
+        val response = errorHandler.handle(Exception(), request)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        val body = response.body as GeneralFailureResponse
+        assertThat(body.message).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.reasonPhrase)
+        assertThat(body.code).isEqualTo("INTERNAL_ERROR")
     }
 
     companion object {

--- a/src/test/kotlin/com/renato/springbootstrap/security/exception/handler/ErrorHandlerTest.kt
+++ b/src/test/kotlin/com/renato/springbootstrap/security/exception/handler/ErrorHandlerTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.authentication.BadCredentialsException
+import org.springframework.mock.web.MockHttpServletRequest
 import java.util.stream.Stream
 
 class ErrorHandlerTest {
@@ -27,28 +28,40 @@ class ErrorHandlerTest {
     fun `given_exception_when_handle_then_returns_expected_status_and_error`(
         exception: Exception,
         expectedStatus: HttpStatus,
+        expectedCode: String,
     ) {
+        val request = MockHttpServletRequest().apply {
+            requestURI = "/api/auth/login"
+        }
+
         val response = when (exception) {
-            is AccessDeniedException -> errorHandler.handle(exception)
-            is UserAlreadyExistsException -> errorHandler.handle(exception)
-            is BadCredentialsException -> errorHandler.handle(exception)
-            is RuntimeException -> errorHandler.handle(exception)
-            else -> errorHandler.handle(exception)
+            is AccessDeniedException -> errorHandler.handle(exception, request)
+            is UserAlreadyExistsException -> errorHandler.handle(exception, request)
+            is BadCredentialsException -> errorHandler.handle(exception, request)
+            is RuntimeException -> errorHandler.handle(exception, request)
+            else -> errorHandler.handle(exception, request)
         }
 
         assertThat(response.statusCode).isEqualTo(expectedStatus)
-        assertThat((response.body as GeneralFailureResponse).errors).containsExactly("myMessage")
+        val body = response.body as GeneralFailureResponse
+        assertThat(body.message).isEqualTo("myMessage")
+        assertThat(body.status).isEqualTo(expectedStatus.value())
+        assertThat(body.error).isEqualTo(expectedStatus.reasonPhrase)
+        assertThat(body.code).isEqualTo(expectedCode)
+        assertThat(body.path).isEqualTo("/api/auth/login")
+        assertThat(body.details).isEmpty()
+        assertThat(body.timestamp).isNotNull()
     }
 
     companion object {
         @JvmStatic
         fun handledExceptions(): Stream<Arguments> {
             return Stream.of(
-                Arguments.of(AccessDeniedException("myMessage"), HttpStatus.FORBIDDEN),
-                Arguments.of(UserAlreadyExistsException("myMessage"), HttpStatus.CONFLICT),
-                Arguments.of(BadCredentialsException("myMessage"), HttpStatus.NOT_FOUND),
-                Arguments.of(Exception("myMessage"), HttpStatus.INTERNAL_SERVER_ERROR),
-                Arguments.of(RuntimeException("myMessage"), HttpStatus.INTERNAL_SERVER_ERROR),
+                Arguments.of(AccessDeniedException("myMessage"), HttpStatus.FORBIDDEN, "ACCESS_DENIED"),
+                Arguments.of(UserAlreadyExistsException("myMessage"), HttpStatus.CONFLICT, "USER_ALREADY_EXISTS"),
+                Arguments.of(BadCredentialsException("myMessage"), HttpStatus.UNAUTHORIZED, "BAD_CREDENTIALS"),
+                Arguments.of(Exception("myMessage"), HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR"),
+                Arguments.of(RuntimeException("myMessage"), HttpStatus.INTERNAL_SERVER_ERROR, "RUNTIME_ERROR"),
             )
         }
     }

--- a/src/test/kotlin/com/renato/springbootstrap/security/exception/handler/ErrorHandlerTest.kt
+++ b/src/test/kotlin/com/renato/springbootstrap/security/exception/handler/ErrorHandlerTest.kt
@@ -51,7 +51,6 @@ class ErrorHandlerTest {
         assertThat(body.error).isEqualTo(expectedStatus.reasonPhrase)
         assertThat(body.code).isEqualTo(expectedCode)
         assertThat(body.path).isEqualTo("/api/auth/login")
-        assertThat(body.details).isEmpty()
         assertThat(body.timestamp).isNotNull()
     }
 
@@ -70,7 +69,6 @@ class ErrorHandlerTest {
         assertThat(body.error).isEqualTo(HttpStatus.UNAUTHORIZED.reasonPhrase)
         assertThat(body.code).isEqualTo("INVALID_TOKEN")
         assertThat(body.path).isEqualTo("/api/auth/refresh")
-        assertThat(body.details).isEmpty()
     }
 
     @Test
@@ -88,7 +86,6 @@ class ErrorHandlerTest {
         assertThat(body.error).isEqualTo(HttpStatus.BAD_REQUEST.reasonPhrase)
         assertThat(body.code).isEqualTo("BAD_REQUEST")
         assertThat(body.path).isEqualTo("/api/users")
-        assertThat(body.details).isEmpty()
     }
 
     @Test
@@ -98,6 +95,20 @@ class ErrorHandlerTest {
         }
 
         val response = errorHandler.handle(RuntimeException("   "), request)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        val body = response.body as GeneralFailureResponse
+        assertThat(body.message).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.reasonPhrase)
+        assertThat(body.code).isEqualTo("RUNTIME_ERROR")
+    }
+
+    @Test
+    fun `given_empty_message_when_handle_then_response_uses_http_reason_phrase`() {
+        val request = MockHttpServletRequest().apply {
+            requestURI = "/api/users"
+        }
+
+        val response = errorHandler.handle(RuntimeException(""), request)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
         val body = response.body as GeneralFailureResponse


### PR DESCRIPTION
## Summary
- refactor GeneralFailureResponse into a REST-oriented error schema (timestamp/status/error/code/message/path/details)
- update global exception handling to return consistent error payloads and more appropriate HTTP statuses (including 401 for bad credentials)
- add and update unit tests for exception handling and GeneralFailureResponse

## Testing
- ./gradlew test --tests com.renato.springbootstrap.security.exception.handler.ErrorHandlerTest
- ./gradlew test --tests com.renato.springbootstrap.api.response.GeneralFailureResponseTest