### PR TITLE
Add dev-only startup banner and dev profile defaults

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,8 @@ server:
   port: ${PORT:8080}
 
 spring:
+  main:
+    banner-mode: off
   threads:
     virtual:
       enabled: true
@@ -44,3 +46,44 @@ spring:
   config:
     activate:
       on-profile: local-postgresql
+---
+
+spring:
+  main:
+    banner-mode: console
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  devtools:
+    add-properties: true
+    restart:
+      enabled: true
+    livereload:
+      enabled: true
+  config:
+    activate:
+      on-profile: dev
+server:
+  error:
+    include-message: always
+    include-binding-errors: always
+    include-stacktrace: on_param
+
+logging:
+  level:
+    com.renato.springbootstrap: DEBUG
+    org.springframework.web: DEBUG
+    org.springframework.security: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE
+
+management:
+  endpoint:
+    health:
+      show-details: always

--- a/src/main/resources/banner.txt
+++ b/src/main/resources/banner.txt
@@ -1,0 +1,10 @@
+${AnsiColor.BRIGHT_GREEN}
+  ____             _             ____              _    ____  _                  
+ / ___| _ __  _ __(_)_ __   __ _| __ )  ___   ___ | |_ / ___|| |_ _ __ __ _ _ __ 
+ \___ \| '_ \| '__| | '_ \ / _` |  _ \ / _ \ / _ \| __|\___ \| __| '__/ _` | '_ \
+  ___) | |_) | |  | | | | | (_| | |_) | (_) | (_) | |_  ___) | |_| | | (_| | |_) |
+ |____/| .__/|_|  |_|_| |_|\__, |____/ \___/ \___/ \__||____/ \__|_|  \__,_| .__/ 
+       |_|                 |___/                                             |_|    
+${AnsiColor.DEFAULT}
+${AnsiStyle.BOLD}:: SpringBootStrap ::${AnsiStyle.NORMAL}
+${AnsiColor.BRIGHT_BLACK}:: version ${application.version:0.1.0} | Java ${java.version} ::${AnsiColor.DEFAULT}


### PR DESCRIPTION
## Summary
- add custom Spring Boot banner in src/main/resources/banner.txt
- disable banner by default and enable it only for dev profile
- add practical dev-only defaults (H2 console, SQL/debug logging, error detail visibility, health details)

## Notes
- production/default profile behavior remains unchanged for banner visibility