### PR TITLE
Add Render deploy GitHub Action after successful main build

### DIFF
--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to Render
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+
+concurrency:
+  group: render-deploy-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Render deploy hook
+        env:
+          RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -z "$RENDER_DEPLOY_HOOK_URL" ]; then
+            echo "Missing required secret: RENDER_DEPLOY_HOOK_URL"
+            exit 1
+          fi
+
+          curl --fail --silent --show-error --request POST "$RENDER_DEPLOY_HOOK_URL"
+          echo "Render deploy hook triggered successfully."

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Configure these secrets in your repository settings:
 |--------|---------|
 | `CODECOV_TOKEN` | Upload coverage reports to Codecov |
 | `SNYK_TOKEN` | Security scanning with Snyk |
+| `RENDER_DEPLOY_HOOK_URL` | Trigger Render deploy after successful `main` image publish |
 
 ## Security
 


### PR DESCRIPTION
## Summary
- add a new workflow to trigger Render deploy via deploy hook
- run deploy only when the Build workflow succeeds on main
- document required secret: RENDER_DEPLOY_HOOK_URL

## How it works
- listens to workflow_run events from the existing Build workflow
- posts to Render deploy hook URL stored in repository secrets