### PR TITLE
Fix Render deploy to use commit SHA image

### DIFF
--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -20,11 +20,16 @@ jobs:
       - name: Trigger Render deploy hook
         env:
           RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+          IMAGE_URL: ghcr.io/fialhorenato/springbootstrap:${{ github.event.workflow_run.head_sha }}
         run: |
           if [ -z "$RENDER_DEPLOY_HOOK_URL" ]; then
             echo "Missing required secret: RENDER_DEPLOY_HOOK_URL"
             exit 1
           fi
 
-          curl --fail --silent --show-error --request POST "$RENDER_DEPLOY_HOOK_URL"
+          # Deploy the exact immutable image tag that was produced by the Build workflow.
+          ENCODED_IMAGE_URL="$(printf '%s' "$IMAGE_URL" | jq -sRr @uri)"
+          DEPLOY_URL="${RENDER_DEPLOY_HOOK_URL}?imgURL=${ENCODED_IMAGE_URL}"
+
+          curl --fail --silent --show-error --request POST "$DEPLOY_URL"
           echo "Render deploy hook triggered successfully."

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to Render
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+
+concurrency:
+  group: render-deploy-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Render deploy hook
+        env:
+          RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -z "$RENDER_DEPLOY_HOOK_URL" ]; then
+            echo "Missing required secret: RENDER_DEPLOY_HOOK_URL"
+            exit 1
+          fi
+
+          curl --fail --silent --show-error --request POST "$RENDER_DEPLOY_HOOK_URL"
+          echo "Render deploy hook triggered successfully."

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Configure these secrets in your repository settings:
 |--------|---------|
 | `CODECOV_TOKEN` | Upload coverage reports to Codecov |
 | `SNYK_TOKEN` | Security scanning with Snyk |
+| `RENDER_DEPLOY_HOOK_URL` | Trigger Render deploy after successful `main` image publish |
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ Configure these secrets in your repository settings:
 | `SNYK_TOKEN` | Security scanning with Snyk |
 | `RENDER_DEPLOY_HOOK_URL` | Trigger Render deploy after successful `main` image publish |
 
+The Render deploy workflow sends `imgURL=ghcr.io/fialhorenato/springbootstrap:<commit-sha>` to the deploy hook so each deploy uses the exact immutable image built on `main`.
+
 ## Security
 
 For security policies, vulnerability reporting, and best practices, please see [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
## Summary
- update Render deploy workflow to pass imgURL with immutable commit SHA tag
- avoid deploying stale latest tag on Render
- document the behavior in README

## Why
Render can redeploy an older mutable tag (latest). Using ghcr image URL with the exact commit SHA makes deploys deterministic.