### PR TITLE
Handle UsernameNotFoundException in API exception handler

### DIFF
--- a/src/main/kotlin/com/renato/springbootstrap/exception/ExceptionHandler.kt
+++ b/src/main/kotlin/com/renato/springbootstrap/exception/ExceptionHandler.kt
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.authentication.BadCredentialsException
+import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import java.time.Instant
@@ -46,6 +47,17 @@ class ExceptionHandler {
         return buildErrorResponse(
             status = HttpStatus.UNAUTHORIZED,
             code = "BAD_CREDENTIALS",
+            message = ex.localizedMessage,
+            request = request,
+        )
+    }
+
+    @ExceptionHandler(UsernameNotFoundException::class)
+    fun handle(ex: UsernameNotFoundException, request: HttpServletRequest): ResponseEntity<GeneralFailureResponse> {
+        logger.warn(ex.localizedMessage, ex)
+        return buildErrorResponse(
+            status = HttpStatus.NOT_FOUND,
+            code = "USER_NOT_FOUND",
             message = ex.localizedMessage,
             request = request,
         )

--- a/src/test/kotlin/com/renato/springbootstrap/security/exception/handler/ErrorHandlerTest.kt
+++ b/src/test/kotlin/com/renato/springbootstrap/security/exception/handler/ErrorHandlerTest.kt
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.authentication.BadCredentialsException
+import org.springframework.security.core.userdetails.UsernameNotFoundException
 import java.util.stream.Stream
 
 class ErrorHandlerTest {
@@ -40,6 +41,7 @@ class ErrorHandlerTest {
             is AccessDeniedException -> errorHandler.handle(exception, request)
             is UserAlreadyExistsException -> errorHandler.handle(exception, request)
             is BadCredentialsException -> errorHandler.handle(exception, request)
+            is UsernameNotFoundException -> errorHandler.handle(exception, request)
             is RuntimeException -> errorHandler.handle(exception, request)
             else -> errorHandler.handle(exception, request)
         }
@@ -137,6 +139,7 @@ class ErrorHandlerTest {
                 Arguments.of(AccessDeniedException("myMessage"), HttpStatus.FORBIDDEN, "ACCESS_DENIED"),
                 Arguments.of(UserAlreadyExistsException("myMessage"), HttpStatus.CONFLICT, "USER_ALREADY_EXISTS"),
                 Arguments.of(BadCredentialsException("myMessage"), HttpStatus.UNAUTHORIZED, "BAD_CREDENTIALS"),
+                Arguments.of(UsernameNotFoundException("myMessage"), HttpStatus.NOT_FOUND, "USER_NOT_FOUND"),
                 Arguments.of(Exception("myMessage"), HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR"),
                 Arguments.of(RuntimeException("myMessage"), HttpStatus.INTERNAL_SERVER_ERROR, "RUNTIME_ERROR"),
             )


### PR DESCRIPTION
## Summary
- add a global exception handler for UsernameNotFoundException
- return 404 Not Found with code USER_NOT_FOUND
- add tests in ErrorHandlerTest for the new mapping

## Validation
- ./gradlew test --tests com.renato.springbootstrap.security.exception.handler.ErrorHandlerTest